### PR TITLE
prevent pm_wait from looping until all servers exited

### DIFF
--- a/lib/FCGI/ProcManager/Dynamic.pm
+++ b/lib/FCGI/ProcManager/Dynamic.pm
@@ -233,8 +233,8 @@ sub pm_wait
 					};
 				};
 				$self->SUPER::n_processes($newnp);
-				$self->{_last_delta_time} = time();
 			};
+			$self->{_last_delta_time} = time();
 		}
 		elsif (keys(%{$self->{PIDS}}) < $self->{n_processes}) 
 		{


### PR DESCRIPTION
The problem appears on iteration when:
- we run at min_nproc and one of the childs exit for some reason
- delta_time has come

We are meeting elsif condition on line 206 but not meeting if condition on line 212 and _last_delta_time is not forwarded in such situation. The loop continues until waitpid returned -1, server keeps running below min_nproc not letting pm_manage to fork workers.
