### PR TITLE
fix elsif order

### DIFF
--- a/lib/FCGI/ProcManager/Dynamic.pm
+++ b/lib/FCGI/ProcManager/Dynamic.pm
@@ -203,6 +203,14 @@ sub pm_wait
 				$self->{_last_delta_time} = time();
 			};
 		}
+		elsif (keys(%{$self->{PIDS}}) < $self->{min_nproc}) 
+		{
+			# Если количество процессов меньше минимального - добавляем
+			$self->pm_notify("increase workers to minimal ".$self->{min_nproc});
+			$self->SUPER::n_processes($self->{min_nproc});
+			$self->{_last_delta_time} = time();
+			$pid = -10;
+		}
 		elsif (($self->{USED_PROCS} < $self->{min_nproc}) && ((time() - $self->{_last_delta_time}) >= $self->{delta_time}))
 		{
 			# Если загруженных процессов меньше минимального количества, уменьшаем на delta_nproc до минимального значения
@@ -240,14 +248,6 @@ sub pm_wait
 		{
 			# Если количество процессов меньше текущего - добавляем
 			$self->pm_notify("increase workers to ".$self->{n_processes});
-			$self->{_last_delta_time} = time();
-			$pid = -10;
-		}
-		elsif (keys(%{$self->{PIDS}}) < $self->{min_nproc}) 
-		{
-			# Если количество процессов меньше минимального - добавляем
-			$self->pm_notify("increase workers to minimal ".$self->{min_nproc});
-			$self->SUPER::n_processes($self->{min_nproc});
 			$self->{_last_delta_time} = time();
 			$pid = -10;
 		}


### PR DESCRIPTION
In some conditions loop could never reach "increase workers count if it is less than min_proc", because earlier `elsif` will steal all the attention.

Imagine that we had `min_proc` running processes, then some of them died (maybe exception, maybe user code just kills processes every X requests). But load is not high and count of actually working processes is lower than `nproc` (probably "equal to `nproc`" will trigger that too).
Now, `elsif (($self->{USED_PROCS} < $self->{min_nproc}) ...` would forever be true. It will not do anything due to internal `if`, but code could never reach `elsif (keys(%{$self->{PIDS}}) < $self->{min_nproc})` and start new processes.
This will continue until server is restarted or last worker process exit for some reason.